### PR TITLE
updated URI.Extension() documentation

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -33,9 +33,9 @@ type URI interface {
 	fmt.Stringer
 
 	// Extension should return the file extension of the resource
-	// referenced by the URI. For example, the Extension() of
-	// 'file://foo/bar.baz' is 'baz'. May return an empty string if the
-	// referenced resource has none.
+	// (including the dot) referenced by the URI. For example, the 
+	// Extension() of 'file://foo/bar.baz' is '.baz'. May return an
+	// empty string if the referenced resource has none.
 	Extension() string
 
 	// Name should return the base name of the item referenced by the URI.


### PR DESCRIPTION
Updated URI.Extension() documentation to clarify that it returns the extension with the dot included.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
I have updated the documentation on `URI.Extension()` to clarify that the returned string includes the dot.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
